### PR TITLE
Bump v0.1.9 policy version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.8
+version: 0.1.9
 name: hostpaths-psp
 displayName: Hostpaths PSP
-createdAt: 2023-03-24T15:15:54.209442298Z
+createdAt: 2023-07-07T16:40:47.632625528Z
 description: A Pod Security Policy that controls usage of hostPath volumes
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/hostpaths-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.8
+  image: ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.9
 keywords:
 - psp
 - hostpaths
 - pod
 links:
 - name: policy
-  url: https://github.com/kubewarden/hostpaths-psp-policy/releases/download/v0.1.8/policy.wasm
+  url: https://github.com/kubewarden/hostpaths-psp-policy/releases/download/v0.1.9/policy.wasm
 - name: source
   url: https://github.com/kubewarden/hostpaths-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.8
+  kwctl pull ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.9
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the artifacthub file bumping the policy version to v0.1.9.

Related to https://github.com/kubewarden/kubewarden-controller/issues/479


