### PR TITLE
chore(deps): tinygo update.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ policy.wasm: $(SOURCE_FILES) go.mod go.sum
 		--rm \
 		-e GOFLAGS="-buildvcs=false" \
 		-v ${PWD}:/src \
-		-w /src tinygo/tinygo:0.33.0 \
+		-w /src tinygo/tinygo:0.39.0 \
 		tinygo build -o policy.wasm -target=wasi -no-debug .
 
 


### PR DESCRIPTION
## Description

To allow a go lang version it's necessary to bump the Tinygo version to v0.39.0.


