### PR TITLE
fix(metadata): revert version

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -49,7 +49,7 @@ annotations:
   # kubewarden specific
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/hostpaths-psp
   io.kubewarden.policy.title: hostpaths-psp
-  io.kubewarden.policy.version: 1.1.0
+  io.kubewarden.policy.version: 1.0.5
   io.kubewarden.policy.description: A Pod Security Policy that controls usage of hostPath volumes
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/hostpaths-psp-policy


### PR DESCRIPTION
## Description

Our CI to release the policies automatically updates the version in the metadata.yml. If this value is changed manually, the CI will not trigger the release PR.

This commit rollback the version in the metadata.yml to allow the CI to start the release process based on the version in the current draft release.

